### PR TITLE
Fix Windows startup, console, and window controls

### DIFF
--- a/src-tauri/src/litebox/windows.rs
+++ b/src-tauri/src/litebox/windows.rs
@@ -24,8 +24,10 @@ pub fn apply_windows_sandbox() -> Result<(), String> {
         let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
         info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE 
             | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
-            | JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
-        info.BasicLimitInformation.ActiveProcessLimit = 10; // Allow some overhead for Tauri/WebView workers
+            | JOB_OBJECT_LIMIT_ACTIVE_PROCESS
+            | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
+        // WebView2 manages its own Chromium sandbox and must create child process jobs.
+        info.BasicLimitInformation.ActiveProcessLimit = 10;
 
         let res = SetInformationJobObject(
             job,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 use lotion_rs::policy::PolicyManager;
 use lotion_rs::security::SecurityModule;
 use lotion_rs::theming::ThemeManager;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -362,9 +362,12 @@ fn main() {
             match lotion_rs::window_controller::WindowController::<tauri::Wry>::new(&handle, security_state) {
                 Ok(wc) => {
                     wc.setup_listeners(handle.clone());
-                    if let Err(e) = wc.setup_tabs(&handle) {
-                        log::error!("Failed to set up tabs: {}", e);
-                    }
+                    let setup_handle = handle.clone();
+                    std::thread::spawn(move || {
+                        if let Err(e) = wc.setup_tabs(&setup_handle) {
+                            log::error!("Failed to set up tabs: {}", e);
+                        }
+                    });
                     log::info!("WindowController initialized and set up.");
                 }
                 Err(e) => {

--- a/src-tauri/src/tab_controller.rs
+++ b/src-tauri/src/tab_controller.rs
@@ -83,6 +83,8 @@ impl<R: Runtime> TabController<R> {
 
                 // 2. Inject Native-feeling Window Controls (Titlebar)
                 window.addEventListener('DOMContentLoaded', () => {{
+                    if ({2}) return;
+
                     const titlebar = document.createElement('div');
                     titlebar.id = 'lotion-custom-titlebar';
                     titlebar.setAttribute('data-tauri-drag-region', '');
@@ -248,7 +250,9 @@ impl<R: Runtime> TabController<R> {
                 }});
             }})();
         "#,
-            tab_id, window_id
+            tab_id,
+            window_id,
+            cfg!(target_os = "windows")
         );
         let _ = webview.eval(&title_observer_js);
 

--- a/src-tauri/src/window_controller.rs
+++ b/src-tauri/src/window_controller.rs
@@ -12,7 +12,7 @@ impl<R: Runtime> WindowController<R> {
         let window = WindowBuilder::new(app, "main")
             .title("lotion-rs")
             .inner_size(1200.0, 768.0)
-            .decorations(false) // Custom injected Mac-like titlebar handles this now
+            .decorations(cfg!(target_os = "windows"))
             .build()?;
 
         // Ensure window state exists in AppState


### PR DESCRIPTION
## Summary
- create the initial tab from a worker thread so Windows WebView2 initialization does not block Tauri's setup/main thread
- allow WebView2 child processes to leave the application Job Object and create their own Chromium sandbox jobs
- keep the lotion-rs process Job Object and UI restrictions enabled
- build Windows release binaries with the GUI subsystem so launching lotion-rs does not open a console window
- use the native Windows title bar with minimize, maximize, close, system-menu, and resize controls
- disable the injected macOS-style controls on Windows to avoid duplicate or unreliable page-level controls

## Root cause
On Windows, startup stopped inside `window.add_child(...)` immediately after the initial Notion tab was requested. Two Windows-specific constraints interacted here:

1. Tauri documents that creating WebViews from synchronous setup/event paths can deadlock WebView2 and recommends a separate thread.
2. The LiteBox Job Object was inherited by WebView2 browser/GPU/renderer processes. The active-process restriction and inability to create child process jobs caused the WebView2 target to crash or never complete initialization.

`JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK` lets WebView2 use its own Chromium sandbox while preserving the Job Object restrictions on the lotion-rs process.

The executable also used the default console subsystem. The release-only `windows_subsystem = "windows"` attribute removes the extra console while retaining it for debug builds.

Finally, the native window had decorations disabled and relied on controls injected into a remote Notion document. Those controls are sensitive to page navigation and remote-page IPC behavior. Windows now uses its native title bar while the custom controls remain available on the other platforms.

## Verification
Tested on Windows 11 x86_64 with WebView2 151.0.4129.101:

- `cargo check --locked`
- `cargo test --locked` (11 passed)
- `cargo build --release --locked`
- confirmed the release PE subsystem is `IMAGE_SUBSYSTEM_WINDOWS_GUI`
- launched the installed release binary and confirmed it remained responsive
- confirmed no `cmd.exe`, `conhost.exe`, `WindowsTerminal.exe`, or `OpenConsole.exe` child process was created
- confirmed native Win32 styles for caption, system menu, minimize button, maximize button, and resizable frame
- confirmed the WebView2 CDP target reached `https://www.notion.com/ja`
- captured the rendered Notion landing page rather than a blank window
- confirmed encrypted application state was saved after initial tab creation